### PR TITLE
Dependency version update and GraphQLProvider refactoring

### DIFF
--- a/book-details/build.gradle
+++ b/book-details/build.gradle
@@ -23,8 +23,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.graphql-java:graphql-java:11.0'
-    implementation 'com.graphql-java:graphql-java-spring-boot-starter-webmvc:1.0'
+    implementation 'com.graphql-java:graphql-java-spring-boot-starter-webmvc:2.0'
     implementation 'com.google.guava:guava:26.0-jre'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/book-details/src/main/java/com/graphqljava/tutorial/bookdetails/GraphQLProvider.java
+++ b/book-details/src/main/java/com/graphqljava/tutorial/bookdetails/GraphQLProvider.java
@@ -24,16 +24,21 @@ public class GraphQLProvider {
 
     @Bean
     public GraphQL graphQL() {
-        InputStream sdl = ClassLoader.getSystemResourceAsStream("schema.graphqls");
-        GraphQLSchema graphQLSchema = buildSchema(sdl);
+        GraphQLSchema graphQLSchema = buildSchema();
         return GraphQL.newGraphQL(graphQLSchema).build();
     }
 
-    private GraphQLSchema buildSchema(InputStream sdl) {
-        TypeDefinitionRegistry typeRegistry = new SchemaParser().parse(sdl);
+    private GraphQLSchema buildSchema() {
+        TypeDefinitionRegistry typeRegistry = buildTypeDefinitionRegistry();
         RuntimeWiring runtimeWiring = buildWiring();
+
         SchemaGenerator schemaGenerator = new SchemaGenerator();
         return schemaGenerator.makeExecutableSchema(typeRegistry, runtimeWiring);
+    }
+
+    private TypeDefinitionRegistry buildTypeDefinitionRegistry(){
+        InputStream sdl = ClassLoader.getSystemResourceAsStream("schema.graphqls");
+        return  new SchemaParser().parse(sdl);
     }
 
     private RuntimeWiring buildWiring() {

--- a/book-details/src/main/java/com/graphqljava/tutorial/bookdetails/GraphQLProvider.java
+++ b/book-details/src/main/java/com/graphqljava/tutorial/bookdetails/GraphQLProvider.java
@@ -1,7 +1,5 @@
 package com.graphqljava.tutorial.bookdetails;
 
-import com.google.common.base.Charsets;
-import com.google.common.io.Resources;
 import graphql.GraphQL;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.idl.RuntimeWiring;
@@ -10,32 +8,28 @@ import graphql.schema.idl.SchemaParser;
 import graphql.schema.idl.TypeDefinitionRegistry;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
-import org.springframework.stereotype.Component;
+import org.springframework.context.annotation.Configuration;
 
-import javax.annotation.PostConstruct;
-import java.io.IOException;
-import java.net.URL;
+import java.io.InputStream;
 
 import static graphql.schema.idl.TypeRuntimeWiring.newTypeWiring;
 
-@Component
+@Configuration
 public class GraphQLProvider {
 
 
     @Autowired
     GraphQLDataFetchers graphQLDataFetchers;
 
-    private GraphQL graphQL;
 
-    @PostConstruct
-    public void init() throws IOException {
-        URL url = Resources.getResource("schema.graphqls");
-        String sdl = Resources.toString(url, Charsets.UTF_8);
+    @Bean
+    public GraphQL graphQL() {
+        InputStream sdl = ClassLoader.getSystemResourceAsStream("schema.graphqls");
         GraphQLSchema graphQLSchema = buildSchema(sdl);
-        this.graphQL = GraphQL.newGraphQL(graphQLSchema).build();
+        return GraphQL.newGraphQL(graphQLSchema).build();
     }
 
-    private GraphQLSchema buildSchema(String sdl) {
+    private GraphQLSchema buildSchema(InputStream sdl) {
         TypeDefinitionRegistry typeRegistry = new SchemaParser().parse(sdl);
         RuntimeWiring runtimeWiring = buildWiring();
         SchemaGenerator schemaGenerator = new SchemaGenerator();
@@ -51,9 +45,5 @@ public class GraphQLProvider {
                 .build();
     }
 
-    @Bean
-    public GraphQL graphQL() {
-        return graphQL;
-    }
 
 }


### PR DESCRIPTION
If merged, this will update dependency versions to the most recent stable one and will change GraphQLProvder from a Component class to a Configuration class which is more suitable for Bean declaration.

Also, it isolates the sdl loading and uses the new overloaded version of SchemaParser::parse with an InputStream parameter instead of a String to generate the TypeDefinitionRegistry.

Edit: Grammar